### PR TITLE
Visualizing costmaps, possibility to read velodyne obstacles

### DIFF
--- a/gazebo_oru/cititruck/cititruck_description/launch/ncfm_two_cititrucks.rviz
+++ b/gazebo_oru/cititruck/cititruck_description/launch/ncfm_two_cititrucks.rviz
@@ -5,19 +5,10 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /Global Options1
-        - /Status1
-        - /Grid1
         - /Grid1/Offset1
-        - /Map1
-        - /Marker1
-        - /TF1
-        - /RobotModel1
-        - /RobotModel2
-        - /Marker2
-        - /Marker3
-        - /MarkerArray1
+        - /NavigationMap1
       Splitter Ratio: 0.5
-    Tree Height: 747
+    Tree Height: 427
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -381,13 +372,23 @@ Visualization Manager:
       Marker Topic: /robot1/visualization_marker
       Name: Marker
       Namespaces:
+        chunks: true
         chunks_dt: true
         chunks_idx0: true
         critical_point: true
+        current_path_idx: true
+        current_path_subsampled: true
+        current_path_subsampled_sw: true
+        docking_path_idx: true
         driven_ct: true
         driven_traj: true
+        earliest_connect_path_idx: true
+        goal_pose2d: true
+        path_smoother_new_path: true
+        path_subsampled: true
         position: true
         robot_id_str: true
+        start_pose2d: true
         state_str: true
       Queue Size: 100
       Value: true
@@ -396,13 +397,24 @@ Visualization Manager:
       Marker Topic: /robot2/visualization_marker
       Name: Marker
       Namespaces:
+        chunks: true
         chunks_dt: true
         chunks_idx0: true
         critical_point: true
+        current_path_idx: true
+        current_path_subsampled: true
+        current_path_subsampled_sw: true
+        docking_path_idx: true
         driven_ct: true
         driven_traj: true
+        earliest_connect_path_idx: true
+        goal_pose2d: true
+        path_points1: true
+        path_smoother_new_path: true
+        path_subsampled: true
         position: true
         robot_id_str: true
+        start_pose2d: true
         state_str: true
       Queue Size: 100
       Value: true
@@ -413,6 +425,16 @@ Visualization Manager:
       Namespaces:
         {}
       Queue Size: 100
+      Value: true
+    - Alpha: 0.699999988
+      Class: rviz/Map
+      Color Scheme: costmap
+      Draw Behind: false
+      Enabled: true
+      Name: NavigationMap
+      Topic: /robot2/generate_path_iliad/iliad_smp_costmap/costmap
+      Unreliable: false
+      Use Timestamp: false
       Value: true
   Enabled: true
   Global Options:
@@ -442,7 +464,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 19.9885998
+      Distance: 28.0825443
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.0599999987
         Stereo Focal Distance: 1
@@ -457,18 +479,18 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.00999999978
-      Pitch: 1.08479691
+      Pitch: 0.894796848
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 4.36855841
+      Yaw: 4.40355778
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1028
+  Height: 722
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000016a0000037afc0200000007fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000000280000037a000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000037afc0200000004fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000028000001330000006400fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000028000000a30000000000000000fb0000000a00560069006500770073010000016100000241000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073f0000003efc0100000002fb0000000800540069006d006501000000000000073f0000030000fffffffb0000000800540069006d00650100000000000004500000000000000000000004ba0000037a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000239fc0200000007fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b00000239000000dc00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000239fc0200000004fb0000001e0054006f006f006c002000500072006f0070006500720074006900650073010000003b000000c40000006400fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000028000000a30000000000000000fb0000000a00560069006500770073010000010400000170000000ae00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000063e0000003efc0100000002fb0000000800540069006d006501000000000000063e000002a400fffffffb0000000800540069006d00650100000000000004500000000000000000000003bb0000023900000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -477,6 +499,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1855
-  X: 55
+  Width: 1598
+  X: 0
   Y: 24

--- a/orunav_launch/launch/motion_planning_and_control_smp.launch
+++ b/orunav_launch/launch/motion_planning_and_control_smp.launch
@@ -2,7 +2,7 @@
 <launch>
   <arg name="robotid" default="1"/>
   <arg name="prefix" default="robot1"/>
-  <arg name="velodyne_in_costmap" default="true"/>
+  <arg name="velodyne_in_costmap" default="false"/>
 
   <group ns="$(arg prefix)">
     <param name="tf_prefix" value="$(arg prefix)" />

--- a/orunav_launch/launch/motion_planning_and_control_smp.launch
+++ b/orunav_launch/launch/motion_planning_and_control_smp.launch
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
-<launch>	
+<launch>
   <arg name="robotid" default="1"/>
   <arg name="prefix" default="robot1"/>
+  <arg name="velodyne_in_costmap" default="true"/>
+
   <group ns="$(arg prefix)">
     <param name="tf_prefix" value="$(arg prefix)" />
-    
+
     <node pkg="orunav_mpc" type="controller_node" name="controller" output="screen">
       <param name="robot_id" value="$(arg robotid)" />
     </node>
@@ -12,11 +14,23 @@
 
     <rosparam file="$(find iliad_smp)/cfg/iliad_smp_costmap.yml" command="load" ns="generate_path_iliad/iliad_smp_costmap/"/>
     <rosparam file="$(find iliad_smp)/cfg/iliad_smp_planner.yml" command="load" ns="generate_path_iliad/iliad_smp"/>
-    <node pkg="iliad_smp" type="generate_path_iliad" name="generate_path_iliad" output="screen">   
+    <group if="$(arg velodyne_in_costmap)">
+      <rosparam param="plugins" ns="generate_path_iliad/iliad_smp_costmap/">
+        - {name: static_map, type: "costmap_2d::StaticLayer"}
+        - {name: obstacle_layer, type: "costmap_2d::ObstacleLayer"}
+      </rosparam>
+
+      <rosparam param="obstacle_layer" ns="generate_path_iliad/iliad_smp_costmap/" subst_value="True">
+        observation_sources: velodyne_sensor
+        velodyne_sensor: {data_type: PointCloud2, sensor_frame: velodyne, topic: /$(arg prefix)/velodyne_points/, marking: true, clearing: true, max_obstacle_height: 1.3, min_obstacle_height: 0.075, obstacle_range: 10.0, raytrace_range: 10.5}
+      </rosparam>
+    </group>
+
+    <node pkg="iliad_smp" type="generate_path_iliad" name="generate_path_iliad" output="screen">
       <param name="min_incr_path_dist" value="0.2" />
       <param name="visualize" value="true" />
     </node>
-    
+
     <node pkg="orunav_constraint_extract" type="polygonconstraint_service" name="polygonconstraint_service" output="screen">
       <param name="load_type" value="1" />
       <param name="model_type" value="2" />
@@ -27,8 +41,8 @@
       <param name="visualize_only_invalid" value="false" />
       <param name="skip_overlap" value="true" />
       <param name="save_lookuptables" value="false" />
-    </node>  
-    
+    </node>
+
     <node pkg="orunav_path_smoother" type="smoothed_path_service" name="smoothed_path_service" output="screen">
       <param name="visualize" value="true" />
       <param name="visualize_deep" value="false" />
@@ -42,23 +56,23 @@
       <param name="reassign_constraints" value="true" />
       <param name="reassign_iters" value="1" />
       <param name="reassign_min_distance" value="0.1" />
-    </node>  
+    </node>
 
     <node pkg="orunav_vehicle_execution" type="orunav_vehicle_execution_node" name="orunav_vehicle_execution_node" output="screen">
       <param name="robot_id" value="$(arg robotid)" />
       <param name="visualize" value="true" />
       <param name="max_tracking_error" value="-1." />
       <param name="use_forks" value="true" />
-      
+
       <param name="max_vel" value="0.5" />
       <param name="max_rotational_vel" value="0.3" />
       <param name="max_acc" value="0.3" />
       <param name="max_steering_angle_vel" value="0.6"/>
-      
+
       <param name="max_steering_range_smoothed_path" value="1.5" />
       <param name="min_docking_distance" value="0.1" />
       <param name="use_ct" value="false"/>
     </node>
-    
+
   </group>
 </launch>


### PR DESCRIPTION
Hi, 
here a pull request to include the possibility to visualize costmaps in an rviz config, and to use the velodyne pointclounds into an obstacle layer of the costmap used by the iliad_smp planner (this allows to see not mapped obstacles).

Best,

Odysseus 